### PR TITLE
Added the url for uu.nl domains

### DIFF
--- a/04-slides.md
+++ b/04-slides.md
@@ -88,6 +88,7 @@ To get your hands on a copy of an existing repository use:
 
 ```
 $ git clone git://github.com/wouter-swierstra/SoftwareProject
+$ git clone <studentnumber>@students.science.uu.nl:/home/projects/<ProjectTitle>/git/<GitRepo>.git
 ```
 
 Note that `git clone` supports several different protocols, including SSH.


### PR DESCRIPTION
Added the git clone URL for the University of Utrecht. The basic url is:

```
<studentnumber>@students.science.uu.nl:/home/projects/<ProjectTitle>/git/<GitRepo>.git
```

The studentnumber is your student number, the ProjectTitle is the title assigned to you by the system administrators of the university of Utrecht and the git/<GitRepo>.git is the file you created during the `$ git init` stage. This should be done via SSH in the projects location. Only you and your team members have access to this file. You will be asked for a password, which is quite logical.

Basically, the git folder and the .git aren't needed per se, but it is just used for managing your projects space to be clean and nice.
